### PR TITLE
refactor: Quote environment variables in all GitHub Actions workflow …

### DIFF
--- a/.github/workflows/build-N1.yml
+++ b/.github/workflows/build-N1.yml
@@ -231,9 +231,9 @@ jobs:
               -v "${{ github.workspace }}/n1/banner:/home/build/immortalwrt/files/mnt/banner" \
               -v "${{ github.workspace }}/n1/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/n1/build.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTFS_PARTSIZE=$rootfs_partsize \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTFS_PARTSIZE="$rootfs_partsize" \
               immortalwrt/imagebuilder:armsr-armv8-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           done
           

--- a/.github/workflows/build-QEMU-arm64-24.10.x.yml
+++ b/.github/workflows/build-QEMU-arm64-24.10.x.yml
@@ -99,11 +99,11 @@ jobs:
               -v "${{ github.workspace }}/armsr-armv8/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/armsr-armv8/build.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e ROOTFS_PARTSIZE=$rootfs_partsize \
-              -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-              -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-              -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+              -e PROFILE="$profile" \
+              -e ROOTFS_PARTSIZE="$rootfs_partsize" \
+              -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+              -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+              -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
               immortalwrt/imagebuilder:armsr-armv8-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           done
       - name: Copy Firmware to workspace

--- a/.github/workflows/build-RaspBerryPi-23.05.4.yml
+++ b/.github/workflows/build-RaspBerryPi-23.05.4.yml
@@ -88,9 +88,9 @@ jobs:
               -v "${{ github.workspace }}/arch/$ARCH:/home/build/immortalwrt/files/etc/opkg/arch.conf" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/raspberrypi/23.05.4/build.sh:/home/build/openwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTSIZE=$size \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTSIZE="$size" \
               immortalwrt/imagebuilder:$tag /bin/bash /home/build/openwrt/build.sh
           done
           ls ${{ github.workspace }}/bin/targets/bcm27xx/${{ env.cpu }}

--- a/.github/workflows/build-RaspBerryPi-24.10.x.yml
+++ b/.github/workflows/build-RaspBerryPi-24.10.x.yml
@@ -103,10 +103,10 @@ jobs:
               -v "${{ github.workspace }}/arch/$ARCH:/home/build/immortalwrt/files/etc/opkg/arch.conf" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/raspberrypi/24.10/build.sh:/home/build/openwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e LUCI_VERSION=$luci_version \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTSIZE=$size \
+              -e PROFILE="$profile" \
+              -e LUCI_VERSION="$luci_version" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTSIZE="$size" \
               immortalwrt/imagebuilder:$tag /bin/bash /home/build/openwrt/build.sh
           done
           ls ${{ github.workspace }}/bin/targets/bcm27xx/${{ env.cpu }}

--- a/.github/workflows/build-boxs-by-ophub.yml
+++ b/.github/workflows/build-boxs-by-ophub.yml
@@ -273,9 +273,9 @@ jobs:
               -v "${{ github.workspace }}/n1/banner:/home/build/immortalwrt/files/mnt/banner" \
               -v "${{ github.workspace }}/n1/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/n1/build.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTFS_PARTSIZE=$rootfs_partsize \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTFS_PARTSIZE="$rootfs_partsize" \
               immortalwrt/imagebuilder:armsr-armv8-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           done
           

--- a/.github/workflows/build-dev-board-by-flippy.yml
+++ b/.github/workflows/build-dev-board-by-flippy.yml
@@ -131,9 +131,9 @@ jobs:
               -v "${{ github.workspace }}/n1/banner:/home/build/immortalwrt/files/mnt/banner" \
               -v "${{ github.workspace }}/n1/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/n1/build.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTFS_PARTSIZE=$rootfs_partsize \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTFS_PARTSIZE="$rootfs_partsize" \
               immortalwrt/imagebuilder:armsr-armv8-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           done
           

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -97,11 +97,11 @@ jobs:
               -v "${{ github.workspace }}/x86-64/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/x86-64/build24.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-              -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-              -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+              -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+              -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
               immortalwrt/imagebuilder:x86-64-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           done
 

--- a/.github/workflows/build-rockchip-immortalWrt-23.05.4.yml
+++ b/.github/workflows/build-rockchip-immortalWrt-23.05.4.yml
@@ -125,12 +125,12 @@ jobs:
               -v "${{ github.workspace }}/rockchip/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/rockchip/build23.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTFS_PARTSIZE=$rootfs_partsize \
-              -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-              -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-              -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTFS_PARTSIZE="$rootfs_partsize" \
+              -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+              -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+              -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
               immortalwrt/imagebuilder:rockchip-armv8-openwrt-23.05.4 /bin/bash /home/build/immortalwrt/build.sh
           done
 

--- a/.github/workflows/build-rockchip-immortalWrt-24.10.x.yml
+++ b/.github/workflows/build-rockchip-immortalWrt-24.10.x.yml
@@ -163,12 +163,12 @@ jobs:
               -v "${{ github.workspace }}/rockchip/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/rockchip/build24.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTFS_PARTSIZE=$rootfs_partsize \
-              -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-              -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-              -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTFS_PARTSIZE="$rootfs_partsize" \
+              -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+              -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+              -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
           immortalwrt/imagebuilder:rockchip-armv8-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
         
     

--- a/.github/workflows/build-sunxi-cortexa53-23.05.4.yml
+++ b/.github/workflows/build-sunxi-cortexa53-23.05.4.yml
@@ -76,9 +76,9 @@ jobs:
               -v "${{ github.workspace }}/arch/arch.conf:/home/build/immortalwrt/files/etc/opkg/arch.conf" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/sunxi-cortexa53/build23.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTSIZE=$size \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTSIZE="$size" \
               immortalwrt/imagebuilder:sunxi-cortexa53-openwrt-23.05.4 /bin/bash /home/build/immortalwrt/build.sh
           done
 

--- a/.github/workflows/build-sunxi-cortexa53-24.10.x.yml
+++ b/.github/workflows/build-sunxi-cortexa53-24.10.x.yml
@@ -91,9 +91,9 @@ jobs:
               -v "${{ github.workspace }}/arch/arch.conf:/home/build/immortalwrt/files/etc/opkg/arch.conf" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/sunxi-cortexa53/build24.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ROOTSIZE=$size \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ROOTSIZE="$size" \
               immortalwrt/imagebuilder:sunxi-cortexa53-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           done
 

--- a/.github/workflows/build-wireless-router.yml
+++ b/.github/workflows/build-wireless-router.yml
@@ -642,11 +642,11 @@ jobs:
               -v "${{ github.workspace }}/arch/arch.conf:/home/build/immortalwrt/files/etc/opkg/arch.conf" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/mediatek-filogic/build24.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-              -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-              -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+              -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+              -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
             immortalwrt/imagebuilder:$tag /bin/bash /home/build/immortalwrt/build.sh
           
 

--- a/.github/workflows/build-x86-64-23.05.4.yml
+++ b/.github/workflows/build-x86-64-23.05.4.yml
@@ -95,11 +95,11 @@ jobs:
               -v "${{ github.workspace }}/x86-64/imm.config:/home/build/immortalwrt/.config" \
               -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
               -v "${{ github.workspace }}/x86-64/build23.sh:/home/build/immortalwrt/build.sh" \
-              -e PROFILE=$profile \
-              -e INCLUDE_DOCKER=$include_docker \
-              -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-              -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-              -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+              -e PROFILE="$profile" \
+              -e INCLUDE_DOCKER="$include_docker" \
+              -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+              -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+              -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
               immortalwrt/imagebuilder:x86-64-openwrt-23.05.4 /bin/bash /home/build/immortalwrt/build.sh
           done
 

--- a/.github/workflows/build-x86-64-24.10.x.yml
+++ b/.github/workflows/build-x86-64-24.10.x.yml
@@ -102,11 +102,11 @@ jobs:
             -v "${{ github.workspace }}/x86-64/imm.config:/home/build/immortalwrt/.config" \
             -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
             -v "${{ github.workspace }}/x86-64/build24.sh:/home/build/immortalwrt/build.sh" \
-            -e PROFILE=$profile \
-            -e INCLUDE_DOCKER=$include_docker \
-            -e ENABLE_PPPOE=${{ inputs.enable_pppoe }} \
-            -e PPPOE_ACCOUNT=${{ inputs.pppoe_account }} \
-            -e PPPOE_PASSWORD=${{ inputs.pppoe_password }} \
+            -e PROFILE="$profile" \
+            -e INCLUDE_DOCKER="$include_docker" \
+            -e ENABLE_PPPOE="${{ inputs.enable_pppoe }}" \
+            -e PPPOE_ACCOUNT="${{ inputs.pppoe_account }}" \
+            -e PPPOE_PASSWORD="${{ inputs.pppoe_password }}" \
           immortalwrt/imagebuilder:x86-64-openwrt-${luci_version} /bin/bash /home/build/immortalwrt/build.sh
           
 


### PR DESCRIPTION
在所有的 Github Actions 工作流中（包括 x86、rockchip、arm64 等架构的 .yml 配置文件），我将传递给 docker run -e 的环境变量（如 PROFILE, PPPOE_ACCOUNT, PPPOE_PASSWORD 等）加上了双引号包裹。这修复了如果用户在这些选项中输入包含空格或特殊字符的字符串时，会导致 Docker 运行参数解析错乱从而导致构建失败的隐藏 Bug。