### PR TITLE
feat: add Raspberry Pi 4B build support for ImmortalWrt 25.12

### DIFF
--- a/.github/workflows/build-RaspBerryPi-25.12.x.yml
+++ b/.github/workflows/build-RaspBerryPi-25.12.x.yml
@@ -1,0 +1,129 @@
+name: Build 25.12.x RaspBerryPi
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        type: choice
+        description: "请选择路由器型号"
+        required: true
+        options:
+          - rpi-3
+          - rpi-4
+          - rpi-5
+        default: rpi-4
+      luci_version:
+        description: "选择luci版本"
+        required: false
+        default: "25.12.0"
+        type: choice
+        options:
+          - 25.12.0
+      enable_store:
+        description: "集成 store 商店（25.12暂不支持）"
+        required: false
+        type: boolean
+        default: false
+      include_docker:
+        description: | 
+          是否编译 Docker 插件
+        required: true
+        default: 'yes'
+        type: choice
+        options:
+          - 'yes'
+          - 'no'
+      size:
+        description: '请输入要编译固件大小 单位(MB)'
+        required: true
+        default: '2048'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set executable permissions
+        run: |
+          chmod +x ${{ github.workspace }}/raspberrypi/25.12/build.sh
+      
+      - name: Enable Store integration
+        run: |
+          if [ "${{ github.event.inputs.enable_store }}" == "true" ]; then
+            echo "⚠️ 25.12 暂不支持 luci-app-store，已忽略"
+          fi
+      
+      - name: Build raspberrypi ImmortalWrt 25.12.x
+        run: |
+          luci_version="${{ github.event.inputs.luci_version }}"
+          profiles="${{ github.event.inputs.profile }}"
+          if [ "$profiles" = "rpi-3" ]; then
+            tag=bcm27xx-bcm2710-openwrt-${luci_version}
+            echo "cpu=bcm2710" >> $GITHUB_ENV
+          elif [ "$profiles" = "rpi-4" ]; then
+            ARCH=rpi4.conf
+            tag=bcm27xx-bcm2711-openwrt-${luci_version}
+            echo "cpu=bcm2711" >> $GITHUB_ENV
+          elif [ "$profiles" = "rpi-5" ]; then
+            ARCH=rpi5.conf
+            tag=bcm27xx-bcm2712-openwrt-${luci_version}
+            echo "cpu=bcm2712" >> $GITHUB_ENV
+          fi
+          include_docker="${{ github.event.inputs.include_docker }}"
+          size="${{ github.event.inputs.size }}"
+          
+          IFS=',' read -r -a profile_array <<< "$profiles"
+          for profile in "${profile_array[@]}"; do
+            echo "Building for profile: $profile"
+            docker run --rm -i \
+              --user root \
+              -v "${{ github.workspace }}/bin:/home/build/immortalwrt/bin" \
+              -v "${{ github.workspace }}/files/etc/uci-defaults:/home/build/immortalwrt/files/etc/uci-defaults" \
+              -v "${{ github.workspace }}/arch/$ARCH:/home/build/immortalwrt/files/etc/opkg/arch.conf" \
+              -v "${{ github.workspace }}/shell:/home/build/immortalwrt/shell" \
+              -v "${{ github.workspace }}/raspberrypi/25.12/build.sh:/home/build/openwrt/build.sh" \
+              -e PROFILE=$profile \
+              -e LUCI_VERSION=$luci_version \
+              -e INCLUDE_DOCKER=$include_docker \
+              -e ROOTSIZE=$size \
+              immortalwrt/imagebuilder:$tag /bin/bash /home/build/openwrt/build.sh
+          done
+          ls ${{ github.workspace }}/bin/targets/bcm27xx/${{ env.cpu }}
+      
+      - name: Create info
+        run: |
+          {
+            echo "## ImmortalWrt 25.12.0 for RPi 4B"
+            echo ""
+            echo "### Pre-installed Plugins"
+            echo "- OpenClash (mihomo core + GeoIP/GeoSite)"
+            echo "- Passwall"
+            echo "- DAED"
+            echo "- DDNS-Go (Cloudflare)"
+            echo "- Docker + dockerd + docker-compose + Docker Manager"
+            echo "- Argon theme + config"
+            echo "- FileBrowser + DiskMan"
+            echo "- TTYD + curl + openssh-sftp-server"
+            echo ""
+            echo "### Defaults"
+            echo "- IP: DHCP (single NIC)"
+            echo "- Size: ${{ github.event.inputs.size }}MB"
+            echo "- Docker: ${{ github.event.inputs.include_docker }}"
+          } > ${{ github.workspace }}/info.md
+ 
+      - name: Upload ImmortalWrt as release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: Autobuild-raspberrypi-25.12
+          body_path: ${{ github.workspace }}/info.md
+          files: |
+            ${{ github.workspace }}/bin/targets/bcm27xx/${{ env.cpu }}/*squashfs-factory.img.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/raspberrypi/25.12/build.sh
+++ b/raspberrypi/25.12/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+source shell/custom-packages.sh
+echo "第三方软件包: $CUSTOM_PACKAGES"
+echo "Building for profile: $PROFILE"
+echo "Include Docker: $INCLUDE_DOCKER"
+echo "Building for ROOTFS_PARTSIZE: $ROOTSIZE"
+
+# 25.12 使用 apk，跳过 run 文件处理（store 在 25.12 暂不支持）
+# 只保留第三方 ipk 包处理
+if [ -n "$CUSTOM_PACKAGES" ]; then
+  # 检查是否有 store 包名，有则跳过（25.12 不支持）
+  if echo "$CUSTOM_PACKAGES" | grep -q "luci-app-store"; then
+    echo "⚠️ 25.12 暂不支持 luci-app-store，已跳过"
+  fi
+  
+  # 如果有其他 run 文件或 ipk，仍然处理
+  if ls /home/build/immortalwrt/extra-packages/*.run 2>/dev/null | head -1; then
+    echo "🔄 处理第三方包..."
+    sh shell/prepare-packages.sh 2>/dev/null || true
+  fi
+fi
+
+LUCI_VERSION="${LUCI_VERSION:-25.12.0}"
+case "$PROFILE" in
+  rpi-3) CPU_ARCH="aarch64_cortex-a53" ;;
+  rpi-4) CPU_ARCH="aarch64_cortex-a72" ;;
+  rpi-5) CPU_ARCH="aarch64_cortex-a76" ;;
+  *)     CPU_ARCH="aarch64_generic" ;;
+esac
+
+echo "✅ 25.12 使用 apk 包管理器"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Starting build process..."
+
+PACKAGES=""
+PACKAGES="$PACKAGES curl"
+PACKAGES="$PACKAGES luci-i18n-firewall-zh-cn"
+PACKAGES="$PACKAGES luci-i18n-filebrowser-go-zh-cn"
+PACKAGES="$PACKAGES luci-theme-argon"
+PACKAGES="$PACKAGES luci-app-argon-config"
+PACKAGES="$PACKAGES luci-i18n-argon-config-zh-cn"
+PACKAGES="$PACKAGES luci-i18n-diskman-zh-cn"
+PACKAGES="$PACKAGES luci-i18n-package-manager-zh-cn"
+PACKAGES="$PACKAGES luci-i18n-ttyd-zh-cn"
+PACKAGES="$PACKAGES openssh-sftp-server"
+
+# 科学上网（25.12 支持 passwall/daed/homeproxy，不支持 nikki）
+PACKAGES="$PACKAGES luci-app-passwall luci-i18n-passwall-zh-cn"
+PACKAGES="$PACKAGES luci-app-daed luci-i18n-daed-zh-cn"
+
+# DDNS-Go
+PACKAGES="$PACKAGES luci-i18n-ddns-go-zh-cn ddns-go"
+
+PACKAGES="$PACKAGES $CUSTOM_PACKAGES"
+
+# Docker
+if [ "$INCLUDE_DOCKER" = "yes" ]; then
+    PACKAGES="$PACKAGES luci-i18n-dockerman-zh-cn docker dockerd docker-compose"
+    echo "Adding Docker packages"
+fi
+
+# OpenClash + mihomo 核心（预装 mihomo 内核+GeoIP）
+PACKAGES="$PACKAGES luci-app-openclash"
+echo "✅ 添加 luci-app-openclash + mihomo 内核"
+mkdir -p files/etc/openclash/core
+# 下载 mihomo 内核（OpenClash 官方源）
+META_URL="https://raw.githubusercontent.com/vernesong/OpenClash/core/master/meta/clash-linux-arm64.tar.gz"
+wget -qO- $META_URL | tar xOvz > files/etc/openclash/core/clash_meta 2>/dev/null && chmod +x files/etc/openclash/core/clash_meta || echo "⚠️ mihomo 内核下载失败"
+# GeoIP/GeoSite
+wget -q https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat -O files/etc/openclash/GeoIP.dat 2>/dev/null
+wget -q https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat -O files/etc/openclash/GeoSite.dat 2>/dev/null
+
+# 构建镜像
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Building image..."
+echo "Packages: $PACKAGES"
+make image PROFILE=$PROFILE PACKAGES="$PACKAGES" FILES="/home/build/immortalwrt/files" ROOTFS_PARTSIZE=$ROOTSIZE
+
+if [ $? -ne 0 ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Error: Build failed!"
+    exit 1
+fi
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Build completed successfully."


### PR DESCRIPTION
## Summary

Adds Raspberry Pi 4B build support for **ImmortalWrt 25.12** (apk-based SDK).

## Changes

### New: `raspberrypi/25.12/build.sh`
Build script for RPi 4B (and RPi 3/5) on ImmortalWrt 25.12:
- **Proxy**: Passwall + DAED (both supported in 25.12)
- **OpenClash**: Pre-installs mihomo core + GeoIP/GeoSite data
- **DDNS-Go**: Cloudflare DDNS support
- **Docker**: Docker + dockerd + docker-compose + Docker Manager (optional)
- **Other**: Argon theme, FileBrowser, DiskMan, TTYD, package-manager

### New: `.github/workflows/build-RaspBerryPi-25.12.x.yml`
GitHub Actions workflow for the 25.12 build:
- Structured Release description listing all pre-installed plugins
- Separate tag (`Autobuild-raspberrypi-25.12`) from the 24.10 builds

## Notes
- Store (luci-app-store) is not supported in 25.12, handled gracefully
- Build tested and confirmed working (RPi 4B), see: https://github.com/YoYo1202/AutoBuildImmortalWrt/actions

## Checklist
- [x] Build script tested and working
- [x] OpenClash + mihomo + GeoIP/GeoSite verified
- [x] DAED + Passwall verified in 25.12 SDK
- [x] Docker optional build verified
- [x] Release description shows all pre-installed plugins
